### PR TITLE
phonies added to makefile instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,12 +2,15 @@ PATH := $(shell pwd)/bin:$(PATH)
 $(shell cp -n dev.env .env)
 include .env
 
+.PHONY: build
 build:
 	docker build --build-arg PHP_VERSION=$(PHP_VERSION) -t $(PHP_DEV_IMAGE) .
 
+.PHONY: install
 install: build
 	composer install
 
+.PHONY: test
 test:
 	vendor/bin/phpunit
 


### PR DESCRIPTION
Phony targets added to Makefile for targets bash autocomplete and potential conflicts resolve. 

see: https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html