### PR TITLE
Make id nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- AbstractResourceObject::$id may be nullable for server-side id generation.
+
 ## [0.0.3] - 2025-03-18
 
 ### Added

--- a/src/FreeElephants/JsonApi/DTO/AbstractResourceObject.php
+++ b/src/FreeElephants/JsonApi/DTO/AbstractResourceObject.php
@@ -10,7 +10,7 @@ use FreeElephants\JsonApi\DTO\Reflection\SuitableRelationshipsTypeDetector;
  */
 class AbstractResourceObject
 {
-    public string $id;
+    public ?string $id = null;
     public string $type;
 
     public function __construct(array $data)


### PR DESCRIPTION
https://jsonapi.org/format/#document-resource-objects

> The id member is not required when the resource object originates at the client and represents a new resource to be created on the server.